### PR TITLE
Add disable open toggle in post editor

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -15,15 +15,17 @@
                             <label for="url">{{capitalize this.post.displayName}} URL</label>
                             {{!-- new posts don't have a preview link --}}
                             {{#unless this.post.isNew}}
-                                {{#if (or this.post.isPublished this.post.isSent)}}
-                                <a class="post-view-link" target="_blank" href="{{this.post.url}}" rel="noopener noreferrer">
-                                    View {{this.post.displayName}} {{svg-jar "arrow-top-right"}}
-                                </a>
-                                {{else if this.post.isScheduled}}
-                                <a class="post-view-link" target="_blank" href="{{this.post.previewUrl}}" rel="noopener noreferrer">
-                                    Preview {{svg-jar "arrow-top-right"}}
-                                </a>
-                                {{/if}}
+                                {{#unless this.post.disableOpen}}
+                                    {{#if (or this.post.isPublished this.post.isSent)}}
+                                    <a class="post-view-link" target="_blank" href="{{this.post.url}}" rel="noopener noreferrer">
+                                        View {{this.post.displayName}} {{svg-jar "arrow-top-right"}}
+                                    </a>
+                                    {{else if this.post.isScheduled}}
+                                    <a class="post-view-link" target="_blank" href="{{this.post.previewUrl}}" rel="noopener noreferrer">
+                                        Preview {{svg-jar "arrow-top-right"}}
+                                    </a>
+                                    {{/if}}
+                                {{/unless}}
                             {{/unless}}
 
                             <div class="gh-input-icon gh-icon-link">
@@ -174,6 +176,25 @@
                                             >
                                             <span class="input-toggle-component"></span>
                                         </span>
+                                    </label>
+                                </div>
+                            </li>
+                            <li class="nav-list-item">
+                                <div class="for-switch xs">
+                                    <label class="switch">
+                                        <span>
+                                            Disable opening
+                                        </span>
+                                        <div class="gh-toggle-featured">
+                                            <input
+                                                type="checkbox"
+                                                checked={{this.post.disableOpen}}
+                                                class="gh-input post-settings-featured gh-input-x"
+                                                {{on "change" this.toggleDisableOpen}}
+                                                data-test-checkbox="disable-open"
+                                            >
+                                            <span class="input-toggle-component"></span>
+                                        </div>
                                     </label>
                                 </div>
                             </li>

--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -233,6 +233,20 @@ export default class GhPostSettingsMenu extends Component {
     }
 
     @action
+    toggleDisableOpen(event) {
+        this.post.disableOpen = event.target.checked;
+
+        if (this.post.isNew) {
+            return;
+        }
+
+        this.savePostTask.perform().catch((error) => {
+            this.showError(error);
+            this.post.rollbackAttributes();
+        });
+    }
+
+    @action
     openPostHistory() {
         this.showPostHistory = true;
     }

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -121,6 +121,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     featureImageAlt: attr('string'),
     featureImageCaption: attr('string'),
     showTitleAndFeatureImage: attr('boolean', {defaultValue: true}),
+    disableOpen: attr('boolean', {defaultValue: false}),
 
     authors: hasMany('user', {embedded: 'always', async: false}),
     createdBy: belongsTo('user', {async: true}),


### PR DESCRIPTION
## Summary
- add `disableOpen` field to post model
- implement toggle for disabling opening posts in the post settings menu
- hide the view link when disabled

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683d005e001c8330b8a5359a2d1265be