### PR TITLE
Add disable open toggle in post editor

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -15,15 +15,17 @@
                             <label for="url">{{capitalize this.post.displayName}} URL</label>
                             {{!-- new posts don't have a preview link --}}
                             {{#unless this.post.isNew}}
-                                {{#if (or this.post.isPublished this.post.isSent)}}
-                                <a class="post-view-link" target="_blank" href="{{this.post.url}}" rel="noopener noreferrer">
-                                    View {{this.post.displayName}} {{svg-jar "arrow-top-right"}}
-                                </a>
-                                {{else if this.post.isScheduled}}
-                                <a class="post-view-link" target="_blank" href="{{this.post.previewUrl}}" rel="noopener noreferrer">
-                                    Preview {{svg-jar "arrow-top-right"}}
-                                </a>
-                                {{/if}}
+                                {{#unless this.post.disableOpen}}
+                                    {{#if (or this.post.isPublished this.post.isSent)}}
+                                    <a class="post-view-link" target="_blank" href="{{this.post.url}}" rel="noopener noreferrer">
+                                        View {{this.post.displayName}} {{svg-jar "arrow-top-right"}}
+                                    </a>
+                                    {{else if this.post.isScheduled}}
+                                    <a class="post-view-link" target="_blank" href="{{this.post.previewUrl}}" rel="noopener noreferrer">
+                                        Preview {{svg-jar "arrow-top-right"}}
+                                    </a>
+                                    {{/if}}
+                                {{/unless}}
                             {{/unless}}
 
                             <div class="gh-input-icon gh-icon-link">
@@ -174,6 +176,25 @@
                                             >
                                             <span class="input-toggle-component"></span>
                                         </span>
+                                    </label>
+                                </div>
+                            </li>
+                            <li class="nav-list-item">
+                                <div class="for-switch xs">
+                                    <label class="switch">
+                                        <span>
+                                            Disable opening
+                                        </span>
+                                        <div class="gh-toggle-featured">
+                                            <input
+                                                type="checkbox"
+                                                checked={{this.post.disableOpen}}
+                                                class="gh-input post-settings-featured gh-input-x"
+                                                {{on "change" this.toggleDisableOpen}}
+                                                data-test-checkbox="disable-open"
+                                            >
+                                            <span class="input-toggle-component"></span>
+                                        </div>
                                     </label>
                                 </div>
                             </li>

--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -233,6 +233,20 @@ export default class GhPostSettingsMenu extends Component {
     }
 
     @action
+    toggleDisableOpen(event) {
+        this.post.disableOpen = event.target.checked;
+
+        if (this.post.isNew) {
+            return;
+        }
+
+        this.savePostTask.perform().catch((error) => {
+            this.showError(error);
+            this.post.rollbackAttributes();
+        });
+    }
+
+    @action
     openPostHistory() {
         this.showPostHistory = true;
     }

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -121,6 +121,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     featureImageAlt: attr('string'),
     featureImageCaption: attr('string'),
     showTitleAndFeatureImage: attr('boolean', {defaultValue: true}),
+    disableOpen: attr('boolean', {defaultValue: false}),
 
     authors: hasMany('user', {embedded: 'always', async: false}),
     createdBy: belongsTo('user', {async: true}),

--- a/ghost/admin/app/serializers/post.js
+++ b/ghost/admin/app/serializers/post.js
@@ -33,6 +33,7 @@ export default class PostSerializer extends ApplicationSerializer.extend(Embedde
         // Page-only properties
         if (snapshot.modelName !== 'page') {
             delete json.show_title_and_feature_image;
+            delete json.disable_open;
         }
 
         if (json.visibility === null) {

--- a/ghost/core/core/frontend/helpers/url.js
+++ b/ghost/core/core/frontend/helpers/url.js
@@ -15,6 +15,10 @@ module.exports = function url(options) {
     const absolute = options && options.hash.absolute && options.hash.absolute !== 'false';
     let outputUrl = getMetaDataUrl(this, absolute);
 
+    if (this?.disable_open) {
+        return new SafeString('#');
+    }
+
     try {
         outputUrl = encodeURI(decodeURI(outputUrl)).replace(/%5B/g, '[').replace(/%5D/g, ']');
     } catch (err) {

--- a/ghost/core/core/frontend/services/proxy.js
+++ b/ghost/core/core/frontend/services/proxy.js
@@ -29,6 +29,7 @@ module.exports = {
 
             // some properties are extracted to local template data to force one way of using it
             delete resource.show_title_and_feature_image;
+            delete resource.disable_open;
         });
     },
 

--- a/ghost/core/core/frontend/services/rendering/format-response.js
+++ b/ghost/core/core/frontend/services/rendering/format-response.js
@@ -79,11 +79,13 @@ function formatResponse(post, context, locals = {}) {
     // - done here rather than `update-local-template-options` middleware because
     //   we need access to the rendered entry's data which isn't available in middleware
     const pageData = {
-        show_title_and_feature_image: true // default behaviour
+        show_title_and_feature_image: true, // default behaviour
+        disable_open: false
     };
 
     // grab data off of the post that will be deleted in prepareContextResource
     const showTitleAndFeatureImage = post.show_title_and_feature_image;
+    const disableOpen = post.disable_open;
 
     prepareContextResource(post);
 
@@ -100,6 +102,9 @@ function formatResponse(post, context, locals = {}) {
         // - data is removed from the post object in prepareContextResource so use of @page is forced
         if (showTitleAndFeatureImage !== undefined) {
             pageData.show_title_and_feature_image = showTitleAndFeatureImage;
+        }
+        if (disableOpen !== undefined) {
+            pageData.disable_open = disableOpen;
         }
     }
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/clean.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/clean.js
@@ -130,6 +130,7 @@ const post = (attrs, frame) => {
 
     if (attrs.type !== 'page') {
         delete attrs.show_title_and_feature_image;
+        delete attrs.disable_open;
     }
 
     delete attrs.locale;

--- a/ghost/core/core/server/data/migrations/versions/5.121/2025-06-02-00-00-00-add-disable-open-column-to-posts.js
+++ b/ghost/core/core/server/data/migrations/versions/5.121/2025-06-02-00-00-00-add-disable-open-column-to-posts.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('posts', 'disable_open', {
+    type: 'boolean',
+    nullable: false,
+    defaultTo: false
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -102,6 +102,7 @@ module.exports = {
         canonical_url: {type: 'text', maxlength: 2000, nullable: true},
         newsletter_id: {type: 'string', maxlength: 24, nullable: true, references: 'newsletters.id'},
         show_title_and_feature_image: {type: 'boolean', nullable: false, defaultTo: true},
+        disable_open: {type: 'boolean', nullable: false, defaultTo: false},
         '@@INDEXES@@': [
             ['type','status','updated_at']
         ],

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -96,7 +96,8 @@ Post = ghostBookshelf.Model.extend({
             tiers,
             visibility: visibility,
             email_recipient_filter: 'all',
-            show_title_and_feature_image: true
+            show_title_and_feature_image: true,
+            disable_open: false
         };
     },
 

--- a/ghost/core/core/server/services/url/config.js
+++ b/ghost/core/core/server/services/url/config.js
@@ -35,6 +35,7 @@ module.exports = [
                 'locale',
                 'newsletter_id',
                 'show_title_and_feature_image',
+                'disable_open',
                 'email_recipient_filter',
                 'comment_id',
                 'tiers'
@@ -88,6 +89,7 @@ module.exports = [
                 'primary_author',
                 'newsletter_id',
                 'show_title_and_feature_image',
+                'disable_open',
                 'email_recipient_filter',
                 'comment_id',
                 'tiers'


### PR DESCRIPTION
## Summary
- add `disable_open` column to posts table and defaults
- include `disable_open` in admin serializer
- expose the flag to themes and sanitize it in API responses
- update URL helper to disable links when `disable_open` is set

## Testing
- `yarn lint` *(fails: nx not found)*
- `yarn test` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d005e001c8330b8a5359a2d1265be