### PR TITLE
Add external URL support for posts

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -44,6 +44,19 @@
                             {{/if}}
                         </div>
 
+                        <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="externalUrl">
+                            <label for="externalUrl">External URL</label>
+                            <GhTextInput
+                                @class="post-setting-externalUrl gh-input-x"
+                                @name="post-setting-externalUrl"
+                                @value={{readonly this.externalUrlScratch}}
+                                @input={{action (mut this.externalUrlScratch) value="target.value"}}
+                                @focus-out={{action "setExternalUrl" this.externalUrlScratch}}
+                                @stopEnterKeyDownPropagation={{true}}
+                                data-test-field="externalUrl" />
+                            <GhErrorMessage @errors={{this.post.errors}} @property="externalUrl" />
+                        </GhFormGroup>
+
                         <div class="form-group">
                             {{#if (or this.post.isDraft this.post.isPublished this.post.pastScheduledTime this.post.isSent)}}
                                 <label>Publish date</label>

--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -33,6 +33,9 @@ export default class GhPostSettingsMenu extends Component {
     @alias('post.canonicalUrlScratch')
         canonicalUrlScratch;
 
+    @alias('post.externalUrlScratch')
+        externalUrlScratch;
+
     @alias('post.customExcerptScratch')
         customExcerptScratch;
 
@@ -410,6 +413,26 @@ export default class GhPostSettingsMenu extends Component {
 
         // Make sure the value is valid and if so, save it into the post
         return post.validate({property: 'canonicalUrl'}).then(() => {
+            if (post.get('isNew')) {
+                return;
+            }
+
+        return this.savePostTask.perform();
+        });
+    }
+
+    @action
+    setExternalUrl(value) {
+        let post = this.post;
+        let currentExternalUrl = post.externalUrl;
+
+        if (currentExternalUrl === value) {
+            return;
+        }
+
+        post.set('externalUrl', value);
+
+        return post.validate({property: 'externalUrl'}).then(() => {
             if (post.get('isNew')) {
                 return;
             }

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -87,6 +87,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     customExcerpt: attr('string'),
     featured: attr('boolean', {defaultValue: false}),
     canonicalUrl: attr('string'),
+    externalUrl: attr('string'),
     codeinjectionFoot: attr('string', {defaultValue: ''}),
     codeinjectionHead: attr('string', {defaultValue: ''}),
     customTemplate: attr('string'),
@@ -148,6 +149,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     publishedAtBlogTime: '',
 
     canonicalUrlScratch: boundOneWay('canonicalUrl'),
+    externalUrlScratch: boundOneWay('externalUrl'),
     customExcerptScratch: boundOneWay('customExcerpt'),
     codeinjectionFootScratch: boundOneWay('codeinjectionFoot'),
     codeinjectionHeadScratch: boundOneWay('codeinjectionHead'),

--- a/ghost/admin/app/validators/post.js
+++ b/ghost/admin/app/validators/post.js
@@ -9,6 +9,7 @@ export default BaseValidator.create({
         'authors',
         'customExcerpt',
         'canonicalUrl',
+        'externalUrl',
         'codeinjectionHead',
         'codeinjectionFoot',
         'metaTitle',
@@ -56,6 +57,24 @@ export default BaseValidator.create({
             this.invalidate();
         } else if (!validator.isLength(model.canonicalUrl, 0, 2000)) {
             model.errors.add('canonicalUrl', 'Canonical URL is too long, max 2000 chars');
+            this.invalidate();
+        }
+    },
+
+    externalUrl(model) {
+        let validatorOptions = {require_protocol: true};
+        let urlRegex = new RegExp(/^(\/|[a-zA-Z0-9-]+:)/);
+        let url = model.externalUrl;
+
+        if (isBlank(url)) {
+            return;
+        }
+
+        if (url.match(/\s/) || (!validator.isURL(url, validatorOptions) && !url.match(urlRegex))) {
+            model.errors.add('externalUrl', 'Please enter a valid URL');
+            this.invalidate();
+        } else if (!validator.isLength(model.externalUrl, 0, 2000)) {
+            model.errors.add('externalUrl', 'External URL is too long, max 2000 chars');
             this.invalidate();
         }
     },

--- a/ghost/admin/tests/unit/validators/post-test.js
+++ b/ghost/admin/tests/unit/validators/post-test.js
@@ -62,4 +62,54 @@ describe('Unit: Validator: post', function () {
             expect(error.message).to.equal('Canonical URL is too long, max 2000 chars');
         });
     });
+
+    describe('externalUrl', function () {
+        it('can be blank', async function () {
+            let post = Post.create({externalUrl: ''});
+            let passed = await post.validate({property: 'externalUrl'}).then(() => true);
+
+            expect(passed, 'passed').to.be.true;
+            expect(post.hasValidated).to.include('externalUrl');
+        });
+
+        it('can be an absolute URL', async function () {
+            let post = Post.create({externalUrl: 'http://example.com'});
+            let passed = await post.validate({property: 'externalUrl'}).then(() => true);
+
+            expect(passed, 'passed').to.be.true;
+            expect(post.hasValidated).to.include('externalUrl');
+        });
+
+        it('can be a relative URL', async function () {
+            let post = Post.create({externalUrl: '/my-other-post'});
+            let passed = await post.validate({property: 'externalUrl'}).then(() => true);
+
+            expect(passed, 'passed').to.be.true;
+            expect(post.hasValidated).to.include('externalUrl');
+        });
+
+        it('cannot be a random string', async function () {
+            let post = Post.create({externalUrl: 'asdfghjk'});
+            let passed = await post.validate({property: 'externalUrl'}).then(() => true).catch(() => false);
+
+            expect(passed, 'passed').to.be.false;
+            expect(post.hasValidated).to.include('externalUrl');
+
+            let error = post.errors.errorsFor('externalUrl').get(0);
+            expect(error.attribute).to.equal('externalUrl');
+            expect(error.message).to.equal('Please enter a valid URL');
+        });
+
+        it('cannot be too long', async function () {
+            let post = Post.create({externalUrl: `http://example.com/${(new Array(1983).join('x'))}`});
+            let passed = await post.validate({property: 'externalUrl'}).then(() => true).catch(() => false);
+
+            expect(passed, 'passed').to.be.false;
+            expect(post.hasValidated).to.include('externalUrl');
+
+            let error = post.errors.errorsFor('externalUrl').get(0);
+            expect(error.attribute).to.equal('externalUrl');
+            expect(error.message).to.equal('External URL is too long, max 2000 chars');
+        });
+    });
 });

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
@@ -3,7 +3,7 @@ const urlUtils = require('../../../../../../../shared/url-utils');
 const localUtils = require('../../../index');
 
 const forPost = (id, attrs, frame) => {
-    attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
+    attrs.url = attrs.external_url || urlService.getUrlByResourceId(id, {absolute: true});
 
     /**
      * CASE: admin api should serve preview urls

--- a/ghost/core/core/server/data/migrations/versions/5.98/2024-10-12-00-00-00-add-external-url-to-posts.js
+++ b/ghost/core/core/server/data/migrations/versions/5.98/2024-10-12-00-00-00-add-external-url-to-posts.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('posts', 'external_url', {
+    type: 'text',
+    maxlength: 2000,
+    nullable: true
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -100,6 +100,7 @@ module.exports = {
         codeinjection_foot: {type: 'text', maxlength: 65535, nullable: true},
         custom_template: {type: 'string', maxlength: 100, nullable: true},
         canonical_url: {type: 'text', maxlength: 2000, nullable: true},
+        external_url: {type: 'text', maxlength: 2000, nullable: true},
         newsletter_id: {type: 'string', maxlength: 24, nullable: true, references: 'newsletters.id'},
         show_title_and_feature_image: {type: 'boolean', nullable: false, defaultTo: true},
         '@@INDEXES@@': [

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -164,7 +164,8 @@ Post = ghostBookshelf.Model.extend({
             'feature_image',
             'og_image',
             'twitter_image',
-            'canonical_url'
+            'canonical_url',
+            'external_url'
         ].forEach((attr) => {
             if (attrs[attr]) {
                 attrs[attr] = urlUtils.transformReadyToAbsolute(attrs[attr]);
@@ -200,6 +201,12 @@ Post = ghostBookshelf.Model.extend({
             og_image: 'toTransformReady',
             twitter_image: 'toTransformReady',
             canonical_url: {
+                method: 'toTransformReady',
+                options: {
+                    ignoreProtocol: false
+                }
+            },
+            external_url: {
                 method: 'toTransformReady',
                 options: {
                     ignoreProtocol: false


### PR DESCRIPTION
## Summary
- add `external_url` column to posts schema and migrations
- convert `external_url` in Post model when reading/writing
- expose `external_url` via Content API and use it for post URL
- support external URL editing in Admin app
- validate `externalUrl` in post validator and add unit tests

## Testing
- `yarn test:unit` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e8ab1a97c8330920d6f3cffdf55c8